### PR TITLE
Rework of audio file parsing/reading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set_target_properties(runstack PROPERTIES ENABLE_EXPORTS TRUE)
 add_library(StackPulseAudioDevice SHARED StackPulseAudioDevice.cpp)
 add_library(StackActionCue SHARED StackActionCue.cpp)
 add_library(StackFadeCue SHARED StackFadeCue.cpp)
-add_library(StackAudioCue SHARED StackAudioCue.cpp MPEGAudioFile.cpp)
+add_library(StackAudioCue SHARED StackAudioCue.cpp StackAudioFile.cpp StackAudioFileWave.cpp StackAudioFileMP3.cpp MPEGAudioFile.cpp)
 include(FindPkgConfig)
 include(FindPackageHandleStandardArgs)
 find_package(PkgConfig REQUIRED)
@@ -26,6 +26,12 @@ find_path(LAME_INCLUDE_DIRS lame/lame.h)
 find_library(LAME_LIBRARIES mp3lame)
 find_package_handle_standard_args(LAME DEFAULT_MSG LAME_INCLUDE_DIRS LAME_LIBRARIES)
 mark_as_advanced(LAME_INCLUDE_DIRS LAME_LIBRARIES LAME_DEFINITIONS)
+
+## MAD doesn't ship with a CMake file
+find_path(MAD_INCLUDE_DIRS mad.h)
+find_library(MAD_LIBRARIES mad)
+find_package_handle_standard_args(MAD DEFAULT_MSG MAD_INCLUDE_DIRS MAD_LIBRARIES)
+mark_as_advanced(MAD_INCLUDE_DIRS MAD_LIBRARIES MAD_DEFINITIONS)
 
 ## SOXR doesn't ship with a CMake file
 find_path(SOXR_INCLUDE_DIRS soxr.h)
@@ -63,6 +69,14 @@ if (LAME_FOUND)
 	include_directories(${LAME_INCLUDE_DIRS})
 	add_definitions(${LAME_DEFINITIONS})
 	target_link_libraries(StackAudioCue ${LAME_LIBRARIES})
+endif()
+
+# Optional: Add in MAD if it was found
+if (MAD_FOUND)
+	list(APPEND MAD_DEFINITIONS -DHAVE_LIBMAD=1)
+	include_directories(${MAD_INCLUDE_DIRS})
+	add_definitions(${MAD_DEFINITIONS})
+	target_link_libraries(StackAudioCue ${MAD_LIBRARIES})
 endif()
 
 # Optional: Add in SOXR if it was found

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,6 @@ pkg_check_modules(JSONCPP REQUIRED jsoncpp)
 ## We need libdl for our plugin loading support
 find_library(DL_LIBRARIES dl REQUIRED)
 
-## LAME doesn't ship with a CMake file
-find_path(LAME_INCLUDE_DIRS lame/lame.h)
-find_library(LAME_LIBRARIES mp3lame)
-find_package_handle_standard_args(LAME DEFAULT_MSG LAME_INCLUDE_DIRS LAME_LIBRARIES)
-mark_as_advanced(LAME_INCLUDE_DIRS LAME_LIBRARIES LAME_DEFINITIONS)
-
 ## MAD doesn't ship with a CMake file
 find_path(MAD_INCLUDE_DIRS mad.h)
 find_library(MAD_LIBRARIES mad)
@@ -61,14 +55,6 @@ if (ALSA_FOUND)
 	include_directories(${ALSA_INCLUDE_DIRS})
 	link_directories(${ALSA_LIBRARY_DIRS})
 	target_link_libraries(StackAlsaAudioDevice ${ALSA_LIBRARY})
-endif()
-
-# Optional: Add in LAME if it was found
-if (LAME_FOUND)
-	list(APPEND LAME_DEFINITIONS -DHAVE_LIBMP3LAME=1)
-	include_directories(${LAME_INCLUDE_DIRS})
-	add_definitions(${LAME_DEFINITIONS})
-	target_link_libraries(StackAudioCue ${LAME_LIBRARIES})
 endif()
 
 # Optional: Add in MAD if it was found

--- a/MPEGAudioFile.cpp
+++ b/MPEGAudioFile.cpp
@@ -252,7 +252,7 @@ bool mpeg_audio_file_find_frames(GInputStream *stream, uint16_t *channels, uint3
 		*channels = mpeg_channels[frame_header.channel_mode];
 
 		// Store the frame details
-		frame_info->push_back(MP3FrameInfo{ total_read, total_samples, samples_per_frame });
+		frame_info->push_back(MP3FrameInfo{ total_read, frame_size, total_samples, samples_per_frame });
 
 		// Move on to the next frame
 		total_samples += samples_per_frame;

--- a/MPEGAudioFile.h
+++ b/MPEGAudioFile.h
@@ -9,6 +9,7 @@
 typedef struct MP3FrameInfo
 {
 	size_t byte_position;       // Location of frame in the file
+	size_t frame_size_bytes;    // The size of the frame in bytes
 	size_t sample_position;	    // The first sample of this frame
 	size_t frame_size_samples;  // The size of the frame in samples
 } MP3FrameInfo;

--- a/StackAudioCue.h
+++ b/StackAudioCue.h
@@ -3,15 +3,9 @@
 
 // Includes:
 #include "StackCue.h"
+#include "StackAudioFile.h"
+#include "StackResampler.h"
 #include <thread>
-
-// Supported file formats
-typedef enum StackAudioFileFormat
-{
-	STACK_AUDIO_FILE_FORMAT_NONE = 0,
-	STACK_AUDIO_FILE_FORMAT_WAVE = 1,
-	STACK_AUDIO_FILE_FORMAT_MP3 = 2,
-} StackAudioFileFormat;
 
 // An audio cue
 typedef struct StackAudioCue
@@ -31,9 +25,6 @@ typedef struct StackAudioCue
 	// media file)
 	stack_time_t media_end_time;
 
-	// The (untrimmed) length of the media file
-	stack_time_t file_length;
-
 	// Post-fade-in, pre-fade-out volume, in dB
 	double play_volume;
 
@@ -43,12 +34,6 @@ typedef struct StackAudioCue
 	// The media tab
 	GtkWidget *media_tab;
 
-	// The audio format
-	StackAudioFileFormat format;
-
-	// Arbitrary per-file data
-	void *file_data;
-
 	// Amount of audio data sent so far in playback
 	stack_time_t playback_data_sent;
 
@@ -56,14 +41,13 @@ typedef struct StackAudioCue
 	double playback_live_volume;
 
 	// The currently open file
-	GFile *playback_file;
-	GFileInputStream *playback_file_stream;
+	StackAudioFile *playback_file;
+
+	// The resampler to resample from file-rate to device-rate
+	StackResampler *resampler;
 
 	// Audio pointer
 	size_t playback_audio_ptr;
-
-	// Arbitrary per-file playback data
-	void *playback_data;
 
 	// Audio Preview: is thread running
 	bool preview_thread_run;

--- a/StackAudioFile.cpp
+++ b/StackAudioFile.cpp
@@ -1,0 +1,186 @@
+// Includes:
+#include "StackAudioFile.h"
+#include "StackAudioFileWave.h"
+#if HAVE_LIBMAD == 1
+#include "StackAudioFileMP3.h"
+#endif
+
+static const float INT8_SCALAR = 7.8125e-3f;
+static const float INT16_SCALAR = 3.051757812e-5f;
+static const float INT24_SCALAR = 1.192092896e-7f;
+static const float INT32_SCALAR = 2.328306437e-10f;
+
+// Helper function that reset the stream file pointer
+static bool stack_audio_file_reset_stream(GFileInputStream *stream)
+{
+	// Reset back to the start of the file
+	g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, NULL);
+	return false;
+}
+
+// Creates a new StackAudioFile object from the supplied file
+StackAudioFile *stack_audio_file_create(const char *uri)
+{
+	StackAudioFile* result = NULL;
+
+	// Open the file
+	GFile *file = g_file_new_for_uri(uri);
+	if (file == NULL)
+	{
+		fprintf(stderr, "stack_audio_file_create(): Failed to open file\n");
+	    return NULL;
+	}
+
+	// Open a stream
+	GFileInputStream *stream = g_file_read(file, NULL, NULL);
+	if (stream == NULL)
+	{
+		fprintf(stderr, "stack_audio_file_create(): Failed to get file input stream\n");
+	    g_object_unref(file);
+	    return NULL;
+	}
+
+	// Attempt to load as the various types
+	if (!((result = (StackAudioFile*)stack_audio_file_create_wave(stream))
+		  || stack_audio_file_reset_stream(stream)
+#if HAVE_LIBMAD == 1
+		  || (result = (StackAudioFile*)stack_audio_file_create_mp3(stream))
+#endif
+		))
+	{
+		fprintf(stderr, "stack_audio_file_create(): Failed to load file as any format\n");
+		g_object_unref(stream);
+		g_object_unref(file);
+	}
+	else
+	{
+		// We set these, we leave the subclasses to set the others
+		result->file = file;
+		result->stream = stream;
+	}
+
+	return result;
+}
+
+// Closes the audio file and destroys the object
+void stack_audio_file_destroy(StackAudioFile *audio_file)
+{
+	// Tidy up common data
+	g_object_unref(audio_file->stream);
+	g_object_unref(audio_file->file);
+
+	// Destroy audio_file depending on what format was returned on creation
+	switch (audio_file->format)
+	{
+		case STACK_AUDIO_FILE_FORMAT_WAVE:
+			stack_audio_file_destroy_wave((StackAudioFileWave*)audio_file);
+			break;
+#if HAVE_LIBMAD == 1
+		case STACK_AUDIO_FILE_FORMAT_MP3:
+			stack_audio_file_destroy_mp3((StackAudioFileMP3*)audio_file);
+			break;
+#endif
+	}
+}
+
+// Seeks to the specific time in the file
+void stack_audio_file_seek(StackAudioFile *audio_file, stack_time_t pos)
+{
+	switch (audio_file->format)
+	{
+		case STACK_AUDIO_FILE_FORMAT_WAVE:
+			stack_audio_file_seek_wave((StackAudioFileWave*)audio_file, pos);
+			break;
+#if HAVE_LIBMAD == 1
+		case STACK_AUDIO_FILE_FORMAT_MP3:
+			stack_audio_file_seek_mp3((StackAudioFileMP3*)audio_file, pos);
+			break;
+#endif
+		default:
+			fprintf(stderr, "stack_audio_file_seek(): Unknown file format\n");
+			break;
+	}
+}
+
+// Read the requested number of frames from the file into buffer
+size_t stack_audio_file_read(StackAudioFile *audio_file, float *buffer, size_t frames)
+{
+	switch (audio_file->format)
+	{
+		case STACK_AUDIO_FILE_FORMAT_WAVE:
+			return stack_audio_file_read_wave((StackAudioFileWave*)audio_file, buffer, frames);
+#if HAVE_LIBMAD == 1
+		case STACK_AUDIO_FILE_FORMAT_MP3:
+			return stack_audio_file_read_mp3((StackAudioFileMP3*)audio_file, buffer, frames);
+#endif
+		default:
+			fprintf(stderr, "stack_audio_file_read(): Unknown file format\n");
+			return -1;
+	}
+}
+
+// TODO: The following functions assume the endianness of the system and the
+// contents of the file are the same... and in the case of int24, assumes that
+// that *both* are Big Endian
+static bool stack_audio_file_convert_int24(const char *input, size_t samples, float *output)
+{
+	for (size_t i = 0; i < samples; i++)
+	{
+		int32_t sample = (*(int32_t*)&input[i * 3] & 0x00ffffff);
+		if (sample & 0x00800000) { sample |= sample | 0xff000000; }
+		output[i] = (float)sample * INT24_SCALAR;
+	}
+
+	return true;
+}
+
+template <typename T> bool stack_audio_file_convert_trivial(const T *input, const size_t samples, float *output, const float scalar)
+{
+	for (size_t i = 0; i < samples; i++)
+	{
+		output[i] = (float)((T*)input)[i] * scalar;
+	}
+
+	return true;
+}
+
+// Converts audio data to system-endian floating point
+bool stack_audio_file_convert(StackSampleFormat format, const void *input, const size_t samples, float *output)
+{
+	switch (format)
+	{
+		case STACK_SAMPLE_FORMAT_INT8:
+			return stack_audio_file_convert_trivial<int8_t>((int8_t*)input, samples, output, INT8_SCALAR);
+		case STACK_SAMPLE_FORMAT_INT16:
+			return stack_audio_file_convert_trivial<int16_t>((int16_t*)input, samples, output, INT16_SCALAR);
+		case STACK_SAMPLE_FORMAT_INT24:
+			return stack_audio_file_convert_int24((char*)input, samples, output);
+		case STACK_SAMPLE_FORMAT_INT32:
+			return stack_audio_file_convert_trivial<int32_t>((int32_t*)input, samples, output, INT32_SCALAR);
+		case STACK_SAMPLE_FORMAT_FLOAT32:
+			memcpy(output, input, sizeof(float) * samples);
+			return true;
+		case STACK_SAMPLE_FORMAT_FLOAT64:
+			return stack_audio_file_convert_trivial<double>((double*)input, samples, output, 1.0f);
+		default:
+			return false;
+	}
+
+	return true;
+}
+
+uint64_t stack_time_to_samples(stack_time_t t, uint32_t sample_rate)
+{
+	uint64_t whole_seconds = t / NANOSECS_PER_SEC;
+	uint64_t remainder_nanosec = t % NANOSECS_PER_SEC;
+	return (whole_seconds * (uint64_t)sample_rate) + (remainder_nanosec * (uint64_t)sample_rate / NANOSECS_PER_SEC);
+
+	// The above is a less integer-overflow-inducing (albeit slightly slower)
+	// way of doing:
+	// return t * sample_rate / NANOSECS_PER_SEC;
+}
+
+uint64_t stack_time_to_bytes(stack_time_t t, uint32_t sample_rate, uint32_t frame_size)
+{
+	return stack_time_to_samples(t, sample_rate) * (uint64_t)frame_size;
+}

--- a/StackAudioFile.h
+++ b/StackAudioFile.h
@@ -1,0 +1,62 @@
+#ifndef _STACKAUDIOFILE_H_INCLUDED
+#define _STACKAUDIOFILE_H_INCLUDED
+
+// Includes:
+#include "StackCue.h"
+#include <gtk/gtk.h>
+
+// Supported file formats
+typedef enum StackAudioFileFormat
+{
+    STACK_AUDIO_FILE_FORMAT_NONE = 0,
+    STACK_AUDIO_FILE_FORMAT_WAVE = 1,
+    STACK_AUDIO_FILE_FORMAT_MP3 = 2,
+	STACK_AUDIO_FILE_FORMAT_OGG = 3, // Reserved for future implementation
+	STACK_AUDIO_FILE_FORMAT_AAC = 4, // Reserved for future implementation
+} StackAudioFileFormat;
+
+typedef enum StackSampleFormat
+{
+	STACK_SAMPLE_FORMAT_UNKNOWN = 0,
+	STACK_SAMPLE_FORMAT_INT8 = 1,
+	STACK_SAMPLE_FORMAT_INT16 = 2,
+	STACK_SAMPLE_FORMAT_INT24 = 3,
+	STACK_SAMPLE_FORMAT_INT32 = 4,
+	STACK_SAMPLE_FORMAT_FLOAT32 = 5,
+	STACK_SAMPLE_FORMAT_FLOAT64 = 6,
+} StackSampleFormat;
+
+typedef struct StackAudioFile
+{
+	StackAudioFileFormat format;
+	size_t channels;
+	size_t sample_rate;
+	stack_time_t length;
+    GFile *file;
+    GFileInputStream *stream;
+} StackAudioFile;
+
+// Opens the audio file at path, and parses any headers. Returns NULL if no
+// supported audio-format could be found or returns something that extends
+// StackAudioFile otherwise
+StackAudioFile *stack_audio_file_create(const char *uri);
+
+// Destroys a StackAudioFile (or extension)
+void stack_audio_file_destroy(StackAudioFile *audio_file);
+
+// Seeks to a the given point (in nanoseconds) in the audio
+void stack_audio_file_seek(StackAudioFile *audio_file, stack_time_t pos);
+
+// Reads frames from the audio file and converts them to float
+size_t stack_audio_file_read(StackAudioFile *audio_file, float *buffer, size_t frames);
+
+// Converts audio data from a given input format to float
+bool stack_audio_file_convert(StackSampleFormat format, const void *input, const size_t samples, float *output);
+
+// Converts a stack_time_t (nanoseconds) to a sample/frame index
+uint64_t stack_time_to_samples(stack_time_t t, uint32_t sample_rate);
+
+// Converts a stack_time_t (nanoseconds) to a byte count
+uint64_t stack_time_to_bytes(stack_time_t t, uint32_t sample_rate, uint32_t frame_size);
+
+#endif

--- a/StackAudioFileMP3.cpp
+++ b/StackAudioFileMP3.cpp
@@ -93,7 +93,7 @@ void stack_audio_file_destroy_mp3(StackAudioFileMP3 *audio_file)
 	stack_ring_buffer_destroy(audio_file->decoded_buffer);
 	if (audio_file->frames_buffer != NULL)
 	{
-		delete audio_file->frames_buffer;
+		delete [] audio_file->frames_buffer;
 	}
 
 	// Tidy up ourselves
@@ -283,6 +283,13 @@ void stack_audio_file_seek_mp3(StackAudioFileMP3 *audio_file, stack_time_t pos)
 
 	// Reset ring buffer
 	stack_ring_buffer_reset(audio_file->decoded_buffer);
+
+	// Reset frames buffer
+	if (audio_file->frames_buffer != NULL)
+	{
+		delete [] audio_file->frames_buffer;
+		audio_file->frames_buffer = NULL;
+	}
 
 	// Determine which sample we're looking for
 	uint64_t start_sample = stack_time_to_samples(pos, audio_file->super.sample_rate);

--- a/StackAudioFileMP3.cpp
+++ b/StackAudioFileMP3.cpp
@@ -1,0 +1,352 @@
+#if HAVE_LIBMAD == 1
+// Includes:
+#include "StackAudioFileMP3.h"
+#include "MPEGAudioFile.h"
+#include <vector>
+
+static const uint16_t DEFAULT_DECODER_DELAY = 529;
+
+typedef struct MP3Info
+{
+	uint32_t sample_rate;
+	uint16_t num_channels;
+	uint64_t num_samples_per_channel;
+	std::vector<MP3FrameInfo> frames;
+} MP3Info;
+
+static bool stack_audio_file_mp3_process(GInputStream *stream, MP3Info *mp3_info)
+{
+    uint32_t frames = 0;
+	mp3_info->num_samples_per_channel = 0;
+
+    if (!mpeg_audio_file_find_frames(stream, &mp3_info->num_channels, &mp3_info->sample_rate, &frames, &mp3_info->num_samples_per_channel, &mp3_info->frames))
+    {
+        fprintf(stderr, "stack_audio_file_mp3_process(): Processing failed\n");
+        return false;
+    }
+
+    // Return whether we succesfully parsed the header
+    return true;
+}
+
+/*static inline float scale_sample(mad_fixed_t sample)
+{
+	static const float INT16_SCALAR = 3.051757812e-5f;
+
+	/*sample += (1L << (MAD_F_FRACBITS - 16));
+	if (sample >= MAD_F_ONE)
+	{
+		sample = MAD_F_ONE - 1;
+	}
+	else if (sample < -MAD_F_ONE)
+	{
+		sample = -MAD_F_ONE;
+	}/
+
+	return (float)(sample >> (MAD_F_FRACBITS + 1 - 16)) * INT16_SCALAR;
+}*/
+
+StackAudioFileMP3 *stack_audio_file_create_mp3(GFileInputStream *stream)
+{
+	MP3Info mp3_info;
+	bool is_mp3_file = stack_audio_file_mp3_process(G_INPUT_STREAM(stream), &mp3_info);
+	if (!is_mp3_file)
+	{
+		return NULL;
+	}
+
+	// Rewind back to the first MP3 frame as we've read the entire file
+	g_seekable_seek(G_SEEKABLE(stream), mp3_info.frames[0].byte_position, G_SEEK_SET, NULL, NULL);
+
+	StackAudioFileMP3 *result = new StackAudioFileMP3;
+	result->super.format = STACK_AUDIO_FILE_FORMAT_MP3;
+	result->super.channels = mp3_info.num_channels;
+	result->super.sample_rate = mp3_info.sample_rate;
+	result->super.length = (stack_time_t)(double(mp3_info.num_samples_per_channel) / double(mp3_info.sample_rate) * NANOSECS_PER_SEC_F);
+	std::swap(result->frames, mp3_info.frames);
+	result->frames_buffer = NULL;
+
+	// Initialise MP3 decoding
+	mad_stream_init(&result->mp3_stream);
+	mad_frame_init(&result->mp3_frame);
+	mad_synth_init(&result->mp3_synth);
+	mad_stream_options(&result->mp3_stream, 0);
+	result->frame_iterator = result->frames.begin();
+	result->delay = 0;
+	result->padding = 0;
+
+	// Create the ring buffer capable of handling two MP3 frames of 1152 audio frames
+	// of two channels
+	result->decoded_buffer = stack_ring_buffer_create(1152 * 4);
+
+	return result;
+}
+
+void stack_audio_file_destroy_mp3(StackAudioFileMP3 *audio_file)
+{
+	// Tidy up MP3 decoder
+	mad_synth_finish(&audio_file->mp3_synth);
+	mad_frame_finish(&audio_file->mp3_frame);
+	mad_stream_finish(&audio_file->mp3_stream);
+
+	// Tidy up buffering
+	stack_ring_buffer_destroy(audio_file->decoded_buffer);
+	if (audio_file->frames_buffer != NULL)
+	{
+		delete audio_file->frames_buffer;
+	}
+
+	// Tidy up ourselves
+	delete audio_file;
+}
+
+static size_t stack_audio_file_mp3_decode_next_mpeg_frame(StackAudioFileMP3 *audio_file)
+{
+	size_t bytes_in_buffer = 0;
+	bool skip_decode = false, current_is_last_frame = false;
+
+	// If we don't have a previous frame, we need to read two
+	if (audio_file->frames_buffer == NULL)
+	{
+		// Get some handy iterators
+		MP3FrameInfoVector::iterator current_frame = audio_file->frame_iterator;
+		MP3FrameInfoVector::iterator next_frame = audio_file->frame_iterator;
+		next_frame++;
+
+		// Work out how many bytes to read for two frames
+		size_t bytes_to_read = current_frame->frame_size_bytes + next_frame->frame_size_bytes;
+
+		// Allocate
+		audio_file->frames_buffer = new unsigned char[bytes_to_read];
+
+		// Read the two frames
+		bytes_in_buffer = g_input_stream_read(G_INPUT_STREAM(audio_file->super.stream), audio_file->frames_buffer, bytes_to_read, NULL, NULL);
+
+		// Check for an info frame (should be the first frame)
+		if (bytes_in_buffer > 40)
+		{
+			unsigned char *h = &audio_file->frames_buffer[36];
+
+			// Skip past the Xing or Info frame if we have one
+			if (h[0] == 'X' && h[1] == 'i' && h[2] == 'n' && h[3] == 'g')
+			{
+				skip_decode = true;
+			}
+			else if (h[0] == 'I' && h[1] == 'n' && h[2] == 'f' && h[3] == 'o')
+			{
+				skip_decode = true;
+			}
+		}
+
+		// If we found a Xing/Info frame, check for a LAME or LAVC header
+		if (skip_decode && bytes_in_buffer > 0x9f)
+		{
+			bool get_delay = false;
+			unsigned char *h = &audio_file->frames_buffer[0x9c];
+			if (h[0] == 'L' && h[1] == 'A' && ((h[2] == 'M' && h[3] == 'E') || (h[2] == 'V' && h[3] == 'E')))
+			{
+				get_delay = true;
+			}
+
+			if (get_delay && bytes_in_buffer > 0xb4)
+			{
+				unsigned char *d = &audio_file->frames_buffer[0xb1];
+
+				// Grab the first 12 bits at 'd' for the delay
+				audio_file->delay = (((uint16_t)d[0] << 4) | ((uint16_t)d[1] & 0xf0) >> 4) + DEFAULT_DECODER_DELAY;
+
+				// Grab the next 12 bits for the padding
+				audio_file->padding = ((((uint16_t)d[1] & 0x0f) << 8) | (uint16_t)d[2]) - DEFAULT_DECODER_DELAY;
+			}
+		}
+	}
+	else
+	{
+		// Get some handy iterators
+		MP3FrameInfoVector::iterator current_frame = audio_file->frame_iterator;
+		MP3FrameInfoVector::iterator previous_frame = audio_file->frame_iterator;
+		previous_frame--;
+		MP3FrameInfoVector::iterator next_frame = audio_file->frame_iterator;
+		next_frame++;
+
+		current_is_last_frame = (next_frame == audio_file->frames.end());
+
+		// Work out how many bytes to read for two frames
+		size_t bytes_to_read;
+		if (!current_is_last_frame)
+		{
+			bytes_to_read = current_frame->frame_size_bytes + next_frame->frame_size_bytes;
+		}
+		else
+		{
+			// On the last frame, we need to add MAD_BUFFER_GUARD zeroes to ensure
+			// the last frame isn't truncated
+			bytes_to_read = current_frame->frame_size_bytes + MAD_BUFFER_GUARD;
+		}
+		unsigned char *new_frames_buffer = new unsigned char[bytes_to_read];
+
+		// Copy in the previous frame from the last buffer
+		memcpy(new_frames_buffer, &audio_file->frames_buffer[previous_frame->frame_size_bytes], current_frame->frame_size_bytes);
+
+		// No longer need the old buffer
+		delete [] audio_file->frames_buffer;
+
+		gssize bytes_read = 0;
+		if (!current_is_last_frame)
+		{
+			// Read in the next frame
+			bytes_read = g_input_stream_read(G_INPUT_STREAM(audio_file->super.stream), &new_frames_buffer[current_frame->frame_size_bytes], next_frame->frame_size_bytes, NULL, NULL);
+		}
+		else
+		{
+			// These are our guard zeros for the last frame
+			memset(&new_frames_buffer[current_frame->frame_size_bytes], 0, MAD_BUFFER_GUARD);
+			bytes_read = MAD_BUFFER_GUARD;
+		}
+
+		// Store the buffer
+		audio_file->frames_buffer = new_frames_buffer;
+
+		// Keep a note of how much data we can process this time
+		bytes_in_buffer = current_frame->frame_size_bytes + bytes_read;
+	}
+
+	// Increment our iterator to move on to the next MPEG frame
+	audio_file->frame_iterator++;
+
+	// If we had an info frame, skip decoding
+	if (skip_decode)
+	{
+		return 0;
+	}
+
+	// Perform the decode
+	mad_stream_buffer(&audio_file->mp3_stream, audio_file->frames_buffer, bytes_in_buffer);
+	mad_frame_decode(&audio_file->mp3_frame, &audio_file->mp3_stream);
+	mad_synth_frame(&audio_file->mp3_synth, &audio_file->mp3_frame);
+
+	// This is the maximum size of a mad_pcm frame, 1152 frames of two channels
+	float scale_buffer[1152 * 2];
+
+	// Perform the scaling from 24-bit int to float
+	size_t frames_to_add = audio_file->mp3_synth.pcm.length;
+	if (audio_file->mp3_synth.pcm.length > 0)
+	{
+		if (audio_file->mp3_synth.pcm.channels == 1)
+		{
+			for (size_t i = audio_file->delay; i < audio_file->mp3_synth.pcm.length; i++)
+			{
+				scale_buffer[i] = (float)mad_f_todouble(audio_file->mp3_synth.pcm.samples[0][i]);
+			}
+		}
+		else if (audio_file->mp3_synth.pcm.channels == 2)
+		{
+			for (size_t i = audio_file->delay; i < audio_file->mp3_synth.pcm.length; i++)
+			{
+				scale_buffer[i*2] = (float)mad_f_todouble(audio_file->mp3_synth.pcm.samples[0][i]);
+				scale_buffer[i*2+1] = (float)mad_f_todouble(audio_file->mp3_synth.pcm.samples[1][i]);
+			}
+		}
+
+		// If we've got a delay, which could be true in the first audio frame,
+		// then we need to skip it, so we need to add fewer samples
+		frames_to_add -= audio_file->delay;
+
+		// If we're in the last frame, then don't add any padding samples we've
+		// discovered
+		if (current_is_last_frame)
+		{
+			frames_to_add -= audio_file->padding;
+		}
+
+		// Write multiplexed data to the ring buffer
+		stack_ring_buffer_write(audio_file->decoded_buffer, &scale_buffer[audio_file->delay * audio_file->mp3_synth.pcm.channels], frames_to_add * audio_file->mp3_synth.pcm.channels, 1);
+
+		// Once we've used the delay, reset it to zero
+		audio_file->delay = 0;
+	}
+
+	// Return how many samples we decoded
+	return frames_to_add;
+}
+
+void stack_audio_file_seek_mp3(StackAudioFileMP3 *audio_file, stack_time_t pos)
+{
+	// Reset synth/frame/stream so we're ready to decode from the start again
+	mad_synth_finish(&audio_file->mp3_synth);
+	mad_frame_finish(&audio_file->mp3_frame);
+	mad_stream_finish(&audio_file->mp3_stream);
+	mad_stream_init(&audio_file->mp3_stream);
+	mad_frame_init(&audio_file->mp3_frame);
+	mad_synth_init(&audio_file->mp3_synth);
+	mad_stream_options(&audio_file->mp3_stream, 0);
+
+	// Reset ring buffer
+	stack_ring_buffer_reset(audio_file->decoded_buffer);
+
+	// Determine which sample we're looking for
+	uint64_t start_sample = stack_time_to_samples(pos, audio_file->super.sample_rate);
+
+	// Iterate through the known frames, and search for the frame that contains
+	// data for our given position
+	size_t previous_frame_position = 0;
+	for (MP3FrameInfoVector::iterator frame = audio_file->frames.begin(); frame != audio_file->frames.end(); frame++)
+	{
+		// If the frame we're looking at contains our start_sample
+		if (frame->sample_position + frame->frame_size_samples >= start_sample)
+		{
+			// We break here meaning so that we don't update
+			// previous_frame_position and thus it points to the byte offset in
+			// the file of the frame prior to the one containing our sample,
+			// which is useful as we need two frames for meaningful output
+
+			// Set our read iterator to the previous frame (where we're about
+			// to seek to)
+			audio_file->frame_iterator = frame;
+			audio_file->frame_iterator--;
+
+			break;
+		}
+
+		// Keep track of the byte position - we need it for seeking
+		previous_frame_position = frame->byte_position;
+	}
+
+	// Seek to the start of the frame before
+	g_seekable_seek(G_SEEKABLE(audio_file->super.stream), previous_frame_position, G_SEEK_SET, NULL, NULL);
+
+	// Decode the next two frames into our buffer
+	stack_audio_file_mp3_decode_next_mpeg_frame(audio_file);
+	stack_audio_file_mp3_decode_next_mpeg_frame(audio_file);
+
+	// Skip past however many samples we additionally decoded before our target sample
+	stack_ring_buffer_skip(audio_file->decoded_buffer, start_sample - audio_file->frame_iterator->sample_position);
+}
+
+size_t stack_audio_file_read_mp3(StackAudioFileMP3 *audio_file, float *buffer, size_t frames)
+{
+	// TODO: Don't hardcode this!
+	size_t channels = 2;
+
+	size_t frames_out = 0;
+	while (frames_out < frames && (audio_file->frame_iterator != audio_file->frames.end() || audio_file->decoded_buffer->used > 0))
+	{
+		// Take an appropriate amount of data from the ring buffer
+		if (audio_file->decoded_buffer->used > 0)
+		{
+			frames_out += stack_ring_buffer_read(audio_file->decoded_buffer, &buffer[frames_out * channels], (frames - frames_out) * channels, 1) / channels;
+		}
+
+		// If there's less than a full MP3 frame in the decoded buffer, and
+		// we're not at the end of the file, decode another frame
+		if (audio_file->decoded_buffer->used < 1152 * channels && audio_file->frame_iterator != audio_file->frames.end())
+		{
+			// Decode more MP3 data
+			stack_audio_file_mp3_decode_next_mpeg_frame(audio_file);
+		}
+	}
+
+	return frames_out;
+}
+
+#endif

--- a/StackAudioFileMP3.h
+++ b/StackAudioFileMP3.h
@@ -1,0 +1,48 @@
+#if HAVE_LIBMAD == 1
+#ifndef _STACKAUDIOFILEMP3_H_INCLUDED
+#define  _STACKAUDIOFILEMP3_H_INCLUDED
+
+// Includes:
+#include "StackAudioFile.h"
+#include "StackRingBuffer.h"
+#include "MPEGAudioFile.h"
+#include <mad.h>
+#include <vector>
+
+typedef std::vector<MP3FrameInfo> MP3FrameInfoVector;
+
+typedef struct StackAudioFileMP3
+{
+	StackAudioFile super;
+
+	MP3FrameInfoVector frames;
+
+	// Our decoder
+	mad_stream mp3_stream;
+	mad_frame mp3_frame;
+	mad_synth mp3_synth;
+
+	// The frame index we're currently decoding
+	MP3FrameInfoVector::iterator frame_iterator;
+
+	// We read in blocks, so we need to buffer
+	StackRingBuffer *decoded_buffer;
+
+	// We always need a minimum of two frames to decode, but we need the two
+	// frames to overlap, so we keep a copy of the old frames
+	unsigned char *frames_buffer;
+
+	// Things we might discover from an info header: encoder delay at start of file
+	uint16_t delay;
+
+	// Padding added in last frame
+	uint16_t padding;
+} StackAudioFileMP3;
+
+StackAudioFileMP3 *stack_audio_file_create_mp3(GFileInputStream *file);
+void stack_audio_file_destroy_mp3(StackAudioFileMP3 *audio_file);
+void stack_audio_file_seek_mp3(StackAudioFileMP3* audio_file, stack_time_t pos);
+size_t stack_audio_file_read_mp3(StackAudioFileMP3 *audio_file, float *buffer, size_t frames);
+
+#endif
+#endif

--- a/StackAudioFileWave.cpp
+++ b/StackAudioFileWave.cpp
@@ -1,0 +1,264 @@
+// Includes:
+#include "StackAudioFileWave.h"
+
+// RIFF Wave header structure
+#pragma pack(push, 2)
+typedef struct WaveHeader
+{
+    char chunk_id[4];
+    uint32_t chunk_size;
+    char format[4];
+    char subchunk_1_id[4];
+    uint32_t subchunk_1_size;
+    uint16_t audio_format;
+    uint16_t num_channels;
+    uint32_t sample_rate;
+    uint32_t byte_rate;
+    uint16_t block_align;
+    uint16_t bits_per_sample;
+    char subchunk_2_id[4];
+    uint32_t subchunk_2_size;
+} WaveHeader;
+#pragma pack(pop)
+
+static bool stack_audio_file_wave_read_header(GInputStream *stream, WaveHeader *header, size_t *data_start_offset, size_t *data_size, StackSampleFormat *format)
+{
+	*data_start_offset = 0;
+
+    if (g_input_stream_read(stream, (void*)header, sizeof(WaveHeader), NULL, NULL) != sizeof(WaveHeader))
+    {
+        fprintf(stderr, "stack_audio_file_wave_read_header(): Failed to read %lu byte header\n", sizeof(WaveHeader));
+        return false;
+    }
+
+    // Check for RIFF header
+    if (!(header->chunk_id[0] == 'R' && header->chunk_id[1] == 'I' && header->chunk_id[2] == 'F' && header->chunk_id[3] == 'F'))
+    {
+        fprintf(stderr, "stack_audio_file_wave_read_header(): Not a Wave file: No RIFF header\n");
+        return false;
+    }
+
+    // Check for WAVE format
+    if (!(header->format[0] == 'W' && header->format[1] == 'A' && header->format[2] == 'V' && header->format[3] == 'E'))
+    {
+        fprintf(stderr, "stack_audio_file_wave_read_header(): Not a Wave file: No WAVEfmt header\n");
+        return false;
+    }
+
+    // Check for 'fmt ' subchunk
+    if (!(header->subchunk_1_id[0] == 'f' && header->subchunk_1_id[1] == 'm' && header->subchunk_1_id[2] == 't' && header->subchunk_1_id[3] == ' '))
+    {
+        fprintf(stderr, "stack_audio_file_wave_read_header(): Failed to find fmt chunk\n");
+        return false;
+    }
+
+    // Check the audio_format. We support PCM (1) and IEEE-float (3)
+	bool valid_format = true;
+	if (header->audio_format == 1)
+	{
+		if (header->bits_per_sample == 8)
+		{
+			*format = STACK_SAMPLE_FORMAT_INT8;
+		}
+		else if (header->bits_per_sample == 16)
+		{
+			*format = STACK_SAMPLE_FORMAT_INT16;
+		}
+		else if (header->bits_per_sample == 24)
+		{
+			*format = STACK_SAMPLE_FORMAT_INT24;
+		}
+		else if (header->bits_per_sample == 32)
+		{
+			*format = STACK_SAMPLE_FORMAT_INT32;
+		}
+		else
+		{
+			valid_format = false;
+		}
+	}
+	else if (header->audio_format == 3)
+	{
+		if (header->bits_per_sample == 32)
+		{
+			*format = STACK_SAMPLE_FORMAT_FLOAT32;
+		}
+		else if (header->bits_per_sample == 64)
+		{
+			*format = STACK_SAMPLE_FORMAT_FLOAT64;
+		}
+		else
+		{
+			valid_format = false;
+		}
+	}
+	else
+	{
+		valid_format = false;
+	}
+
+	if (!valid_format)
+    {
+        fprintf(stderr, "stack_audio_file_wave_read_header(): Non-PCM audio format (%d) is not supported\n", header->audio_format);
+        return false;
+    }
+
+    // If the byte rate isn't given, calculate it
+    if (header->byte_rate == 0)
+    {
+        header->byte_rate = header->sample_rate * header->num_channels * header->bits_per_sample / 8;
+    }
+
+    // Check that our second subchunk is "data"
+    if (header->subchunk_2_id[0] == 'd' && header->subchunk_2_id[1] == 'a' && header->subchunk_2_id[2] == 't' && header->subchunk_2_id[3] == 'a')
+    {
+		*data_start_offset = sizeof(WaveHeader);
+		*data_size = header->subchunk_2_size;
+        return true;
+    }
+
+    // If our second subchunk is not data, search for the subchunk
+
+    // Seek past chunk 2 (we've already read it's size as part of the normal
+    // WaveHeader structure)
+    g_seekable_seek(G_SEEKABLE(stream), header->subchunk_2_size, G_SEEK_CUR, NULL, NULL);
+	*data_start_offset = sizeof(WaveHeader) + header->subchunk_2_size;
+
+    // Find the data chunk
+    bool found_data_chunk = false;
+    while (!found_data_chunk)
+    {
+        char chunk_id[4];
+        uint32_t subchunk_size;
+
+        // Read chunk ID and size
+        if (g_input_stream_read(stream, &chunk_id, 4, NULL, NULL) == 4 && g_input_stream_read(stream, &subchunk_size, 4, NULL, NULL) == 4)
+        {
+            // If the chunk ID is data
+            if (chunk_id[0] == 'd' && chunk_id[1] == 'a' && chunk_id[2] == 't' && chunk_id[3] == 'a')
+            {
+				// Keep track of our offset in the file
+				*data_start_offset += 8;
+				*data_size = subchunk_size;
+
+                // Stop searching
+                found_data_chunk = true;
+            }
+            else
+            {
+                // Seek past the chunk
+                g_seekable_seek(G_SEEKABLE(stream), subchunk_size, G_SEEK_CUR, NULL, NULL);
+
+				// Keep track of our offset in the file
+				*data_start_offset += subchunk_size;
+            }
+        }
+        else
+        {
+            fprintf(stderr, "stack_audio_file_wave_read_header(): Failed to read chunk ID\n");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+StackAudioFileWave *stack_audio_file_create_wave(GFileInputStream *stream)
+{
+	WaveHeader header;
+	size_t data_start_offset, data_size;
+	StackSampleFormat format = STACK_SAMPLE_FORMAT_UNKNOWN;
+	bool is_wave_file = stack_audio_file_wave_read_header(G_INPUT_STREAM(stream), &header, &data_start_offset, &data_size, &format);
+	if (!is_wave_file)
+	{
+		return NULL;
+	}
+
+	// We've got a wave file, so set up our result
+	StackAudioFileWave *result = new StackAudioFileWave;
+	result->super.format = STACK_AUDIO_FILE_FORMAT_WAVE;
+	result->super.channels = header.num_channels;
+	result->super.sample_rate = header.sample_rate;
+	result->super.length = (stack_time_t)(double(header.subchunk_2_size) / double(header.byte_rate) * NANOSECS_PER_SEC_F);
+	result->frame_size = header.num_channels * header.bits_per_sample / 8;
+	result->sample_format = format;
+	result->data_start_offset = data_start_offset;
+	result->data_size = data_size;
+	result->data_read = 0;
+
+	return result;
+}
+
+void stack_audio_file_destroy_wave(StackAudioFileWave *audio_file)
+{
+	delete audio_file;
+}
+
+void stack_audio_file_seek_wave(StackAudioFileWave *audio_file, stack_time_t pos)
+{
+	uint64_t target_data_byte = stack_time_to_bytes(pos, audio_file->super.sample_rate, audio_file->frame_size);
+	uint64_t seek_point = audio_file->data_start_offset + target_data_byte;
+
+	// Seek to the right point in the file
+	g_seekable_seek(G_SEEKABLE(audio_file->super.stream), seek_point, G_SEEK_SET, NULL, NULL);
+	audio_file->data_read = target_data_byte;
+}
+
+size_t stack_audio_file_read_wave(StackAudioFileWave *audio_file, float *buffer, size_t frames)
+{
+	size_t frames_read = 0, samples_read = 0;
+
+	// If you ask for nothing, or we're already at the end of the file, you get
+	// nothing and we can return immediately
+	if (frames == 0 || audio_file->data_read >= audio_file->data_size)
+	{
+		return 0;
+	}
+
+	// Figure out how much to read in bytes, without going past the end of the
+	// data chunk
+	size_t bytes_to_read = audio_file->frame_size * frames;
+	if (audio_file->data_read + bytes_to_read > audio_file->data_size)
+	{
+		bytes_to_read = audio_file->data_size - audio_file->data_read;
+	}
+
+	// If the data format in the file is float32, we can read directly in to the
+	// output buffer, else we have to allocate some memory
+	char *read_buffer = NULL;
+	if (audio_file->sample_format == STACK_SAMPLE_FORMAT_FLOAT32)
+	{
+		read_buffer = (char*)buffer;
+	}
+	else
+	{
+		read_buffer = new char[bytes_to_read];
+	}
+
+	// Read into the buffer
+	gssize bytes_read = g_input_stream_read(G_INPUT_STREAM(audio_file->super.stream), read_buffer, bytes_to_read, NULL, NULL);
+
+	if (bytes_read > 0)
+	{
+		// Keep track of how much data we've read
+		audio_file->data_read += bytes_read;
+
+		// Work out how many frames we actually read which could be less than
+		// was requested
+		frames_read = bytes_read / audio_file->frame_size;
+
+		// Perform the conversion from whatever format we had to float32
+		if (audio_file->sample_format != STACK_SAMPLE_FORMAT_FLOAT32)
+		{
+			stack_audio_file_convert(audio_file->sample_format, read_buffer, frames_read * audio_file->super.channels, buffer);
+		}
+	}
+
+	// Tidy up
+	if (audio_file->sample_format != STACK_SAMPLE_FORMAT_FLOAT32)
+	{
+		delete [] read_buffer;
+	}
+
+	return frames_read;
+}

--- a/StackAudioFileWave.h
+++ b/StackAudioFileWave.h
@@ -1,0 +1,32 @@
+#ifndef _STACKAUDIOFILEWAVE_H_INCLUDED
+#define _STACKAUDIOFILEWAVE_H_INCLUDED
+
+// Includes:
+#include "StackAudioFile.h"
+
+typedef struct StackAudioFileWave
+{
+	StackAudioFile super;
+
+	// Format of the audio data
+	StackSampleFormat sample_format;
+
+	// The size of a single frame of data, in bytes (e.g. 2 channels * 32 bits-per-sample / 8 bits-per-byte = 8 bytes)
+	size_t frame_size;
+
+	// The offset of the start of the actual wave data in the file, in bytes
+	size_t data_start_offset;
+
+	// The size of the data
+	size_t data_size;
+
+	// The amount of the data chunk we've read, in bytes
+	size_t data_read;
+} StackAudioFileWave;
+
+StackAudioFileWave *stack_audio_file_create_wave(GFileInputStream *file);
+void stack_audio_file_destroy_wave(StackAudioFileWave *audio_file);
+void stack_audio_file_seek_wave(StackAudioFileWave *audio_file, stack_time_t pos);
+size_t stack_audio_file_read_wave(StackAudioFileWave *audio_file, float *buffer, size_t frames);
+
+#endif


### PR DESCRIPTION
Remove all of the code for reading/parsing audio files from StackAudioCue and split out in to a separate generic StackAudioFile object, which is a mostly-dumb interface to StackAudioFileWave and StackAudioFileMP3. This removes ~800 lines of complication and code duplicate from StackAudioCue.

This PR also starts using the StackResampler that was previously added, so that files whose sample rate does not match that of the current audio device get automatically resampled.

Also resolves #4 - the new MP3 decoding setup uses libmad instead of libmp3lame, which removes the thread-safety issue.