### PR TITLE
Add Ogg Vorbis support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ add_custom_command(
 add_custom_target(stacktimetrigger-resources-target DEPENDS src/stacktimetrigger-resources.c)
 set_source_files_properties(src/stacktimetrigger-resources.c PROPERTIES GENERATED TRUE)
 
-set(STACK_SOURCES src/StackLog.cpp src/StackProperty.cpp src/StackRingBuffer.cpp src/StackGtkHelper.cpp src/StackJson.cpp src/StackCue.cpp src/StackCueBase.cpp src/StackCueHelper.cpp src/StackCueList.cpp src/StackTrigger.cpp src/StackGroupCue.cpp src/StackApp.cpp src/StackWindow.cpp src/StackCueListWidget.cpp src/StackShowSettings.cpp src/main.cpp src/StackAudioDevice.cpp src/StackRenumberCue.cpp src/StackResampler.cpp src/StackLevelMeter.cpp src/StackAudioPreview.cpp src/StackAudioFile.cpp src/StackAudioFileWave.cpp src/StackAudioFileMP3.cpp src/MPEGAudioFile.cpp src/StackAudioLevelsTab.cpp src/resources.c)
+set(STACK_SOURCES src/StackLog.cpp src/StackProperty.cpp src/StackRingBuffer.cpp src/StackGtkHelper.cpp src/StackJson.cpp src/StackCue.cpp src/StackCueBase.cpp src/StackCueHelper.cpp src/StackCueList.cpp src/StackTrigger.cpp src/StackGroupCue.cpp src/StackApp.cpp src/StackWindow.cpp src/StackCueListWidget.cpp src/StackShowSettings.cpp src/main.cpp src/StackAudioDevice.cpp src/StackRenumberCue.cpp src/StackResampler.cpp src/StackLevelMeter.cpp src/StackAudioPreview.cpp src/StackAudioFile.cpp src/StackAudioFileWave.cpp src/StackAudioFileMP3.cpp src/StackAudioFileOgg.cpp src/MPEGAudioFile.cpp src/StackAudioLevelsTab.cpp src/resources.c)
 #set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
 #set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
 add_library(StackPulseAudioDevice SHARED src/StackPulseAudioDevice.cpp)
@@ -121,6 +121,7 @@ find_package(Threads REQUIRED)
 find_package(ALSA)
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)
 pkg_check_modules(PIPEWIRE libpipewire-0.3)
+pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
 
 ## We need libdl for our plugin loading support
 find_library(DL_LIBRARIES dl REQUIRED)
@@ -197,6 +198,16 @@ if (MAD_FOUND)
 	endif()
 	add_definitions(${MAD_DEFINITIONS})
 	target_link_libraries(runstack ${MAD_LIBRARIES})
+endif()
+
+# Optional: Add in Vorbisfile if it was found
+if (VORBISFILE_FOUND)
+	list(APPEND VORBISFILE_DEFINITIONS -DHAVE_VORBISFILE=1)
+	if (VORBISFILE_INCLUDE_DIRS)
+		include_directories(${VORBISFILE_INCLUDE_DIRS})
+	endif()
+	add_definitions(${VORBISFILE_DEFINITIONS})
+	target_link_libraries(runstack ${VORBISFILE_LIBRARIES})
 endif()
 
 # Optional: Add in SOXR if it was found

--- a/Dockerfile.rocky
+++ b/Dockerfile.rocky
@@ -7,7 +7,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${R
 RUN yum -y install --enablerepo=devel cmake gcc-c++ pkg-config gtk3 gtk3-devel \
   glib2 glib2-devel pulseaudio-libs pulseaudio-libs-devel alsa-lib \
   alsa-lib-devel libmad libmad-devel soxr soxr-devel jsoncpp jsoncpp-devel \
-  protobuf-c protobuf-c-devel
+  protobuf-c protobuf-c-devel libvorbis-devel
 
 ARG RELEASE
 RUN echo "$RELEASE"; \
@@ -17,4 +17,12 @@ RUN echo "$RELEASE"; \
 
 COPY . /stack
 
-RUN cd /stack; rm -rf CMakeCache.txt CMakeFiles; cmake .; make -j 8
+RUN cd /stack; \
+  rm -rf CMakeCache.txt CMakeFiles; \
+  cmake .; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null | grep -o -e -DHAVE_LIBMAD=1 || echo " - No MP3 support"; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null  | grep -o -e -DHAVE_LIBPROTOBUF_C=1 || echo " - No gRPC support"; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null  | grep -o -e -DHAVE_LIBSOXR=1 || echo " - No resampling support"; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null  | grep -o -e -DHAVE_LIBVORBISFILE=1 || echo " - No Ogg Vorbis support"; \
+  grep -o ^PIPEWIRE_FOUND:INTERNAL=1 CMakeCache.txt > /dev/null || echo "No PipeWire support"; \
+  make -j 8

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,7 +7,7 @@ RUN apt update
 RUN DEBIAN_FRONTEND="noninteractive" DEBCONF_NONINTERACTIVE_SEEN="true" \
   apt -y install cmake g++ pkg-config libgtk-3-0 libgtk-3-dev libglib2.0-dev \
   libpulse0 libpulse-dev libasound2-dev libmad0 libmad0-dev libsoxr0 \
-  libsoxr-dev libprotobuf-c1 libprotobuf-c-dev
+  libsoxr-dev libprotobuf-c1 libprotobuf-c-dev libvorbis-dev
 
 ARG RELEASE
 RUN echo "$RELEASE"; \
@@ -24,4 +24,12 @@ RUN echo "$RELEASE"; \
 
 COPY . /stack
 
-RUN cd /stack; rm -rf CMakeCache.txt CMakeFiles; cmake .; make -j 8
+RUN cd /stack; \
+  rm -rf CMakeCache.txt CMakeFiles; \
+  cmake .; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null | grep -o -e -DHAVE_LIBMAD=1 || echo " - No MP3 support"; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null  | grep -o -e -DHAVE_LIBPROTOBUF_C=1 || echo " - No gRPC support"; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null  | grep -o -e -DHAVE_LIBSOXR=1 || echo " - No resampling support"; \
+  grep ^CXX_DEFINES CMakeFiles/runstack.dir/flags.make >/dev/null  | grep -o -e -DHAVE_LIBVORBISFILE=1 || echo " - No Ogg Vorbis support"; \
+  grep -o ^PIPEWIRE_FOUND:INTERNAL=1 CMakeCache.txt > /dev/null || echo "No PipeWire support"; \
+  make -j 8

--- a/README.md
+++ b/README.md
@@ -9,24 +9,25 @@ using Gtk+, aiming to bring efficient, stable show control to Linux.
 
 Cues:
 * Audio Cues
-  * Playback from Wave and MP3
+  * Playback from Wave, Ogg Vorbis and MP3
   * Start/end trim points
   * Loops
   * Resampling when device/file sample rates differ
+  * Custom playback rates
 * Fade Cues
   * Choice of fade profiles
 * Action Cues: Start/Stop/Pause other cues
 * Execute Cues: Run arbitrary programs/commands/scripts
 * Group Cues: various modes when playing:
   * Trigger all child cues
-  * Trigger random cchild cue
+  * Trigger random child cue
   * Trigger children in order as a playlist
   * Trigger children in random order as a shuffled playlist
 
 Cue Triggers:
 * Spacebar to play next cue in playlist
 * Custom key triggers to play/pause/stop cues when a key is pressed/released
-* Timed cue triggers to fire at a given date/time, optionally repeatng
+* Timed cue triggers to fire at a given date/time, optionally repeating
 
 Outputs:
 * PipeWire
@@ -69,6 +70,7 @@ their development packages) to compile and run Stack:
 * libsoxr (optional, required for resampling)
 * protobuf-c (optional, required for remote control)
 * libpipewire-0.3 (optional, required for PipeWire audio devices)
+* libvorbisfile3 (optional, required for Ogg Vorbis playback)
 
 For **Ubuntu 24.04 and newer**, this list of dependencies can be installed with:
 
@@ -76,7 +78,7 @@ For **Ubuntu 24.04 and newer**, this list of dependencies can be installed with:
 sudo apt install cmake g++ pkg-config libgtk-3-0 libgtk-3-dev libglib2.0-dev \
   libpulse0 libpulse-dev libasound2t64 libasound2-dev libjsoncpp25 libjsoncpp-dev \
   libmad0 libmad0-dev libsoxr0 libsoxr-dev libprotobuf-c1 libprotobuf-c-dev \
-  libpipewire-0.3-dev
+  libpipewire-0.3-dev libvorbis-dev
 ```
 
 For **Ubuntu 22.04 and newer**, this list of dependencies can be installed with:
@@ -84,7 +86,8 @@ For **Ubuntu 22.04 and newer**, this list of dependencies can be installed with:
 ```shell
 sudo apt install cmake g++ pkg-config libgtk-3-0 libgtk-3-dev libglib2.0-dev \
   libpulse0 libpulse-dev libasound2 libasound2-dev libjsoncpp25 libjsoncpp-dev \
-  libmad0 libmad0-dev libsoxr0 libsoxr-dev libprotobuf-c1 libprotobuf-c-dev
+  libmad0 libmad0-dev libsoxr0 libsoxr-dev libprotobuf-c1 libprotobuf-c-dev \
+  libvorbis-dev
 ```
 
 For **Ubuntu 20.04**, the slight variation on the above is:
@@ -92,7 +95,8 @@ For **Ubuntu 20.04**, the slight variation on the above is:
 ```shell
 sudo apt install cmake g++ pkg-config libgtk-3-0 libgtk-3-dev libglib2.0-dev \
   libpulse0 libpulse-dev libasound2 libasound2-dev libjsoncpp1 libjsoncpp-dev \
-  libmad0 libmad0-dev libsoxr0 libsoxr-dev libprotobuf-c1 libprotobuf-c-dev
+  libmad0 libmad0-dev libsoxr0 libsoxr-dev libprotobuf-c1 libprotobuf-c-dev \
+  libvorbis-dev
 ```
 
 For **Rocky Linux**, you will first need the EPEL repository configured,
@@ -111,7 +115,7 @@ The list of dependencies can be installed with:
 yum -y install --enablerepo=devel cmake gcc-c++ pkg-config gtk3 gtk3-devel \
   glib2 glib2-devel pulseaudio-libs pulseaudio-libs-devel alsa-lib \
   alsa-lib-devel libmad libmad-devel soxr soxr-devel jsoncpp jsoncpp-devel \
-  protobuf-c protobuf-c-devel
+  protobuf-c protobuf-c-devel libvorbis-devel
 ```
 
 For Rocky Linux 9, you will also need PipeWire:

--- a/src/StackAudioCue.cpp
+++ b/src/StackAudioCue.cpp
@@ -552,18 +552,40 @@ static void acp_file_choose(GtkWidget *widget, gpointer user_data)
 
 	// Add filters to it (the file chooser takes ownership, so we don't have to tidy them up)
 	GtkFileFilter *supported_filter = gtk_file_filter_new();
+#if HAVE_LIBMAD == 1
 	gtk_file_filter_add_pattern(supported_filter, "*.mp3");
+#endif
 	gtk_file_filter_add_pattern(supported_filter, "*.wav");
-	gtk_file_filter_set_name(supported_filter, "All Supported Files (*.mp3,*.wav)");
+#if HAVE_VORBISFILE == 1
+	gtk_file_filter_add_pattern(supported_filter, "*.ogg");
+	gtk_file_filter_add_pattern(supported_filter, "*.oga");
+#endif
+	gtk_file_filter_set_name(supported_filter, "All Supported Files (*.wav"
+#if HAVE_VORBISFILE == 1
+	",*.ogg,*.oga"
+#endif
+#if HAVE_LIBMAD == 1
+	",*.mp3"
+#endif
+	")");
 	gtk_file_chooser_add_filter(chooser, supported_filter);
 	GtkFileFilter *wav_filter = gtk_file_filter_new();
 	gtk_file_filter_add_pattern(wav_filter, "*.wav");
 	gtk_file_filter_set_name(wav_filter, "Wave Files (*.wav)");
 	gtk_file_chooser_add_filter(chooser, wav_filter);
+#if HAVE_LIBMAD == 1
 	GtkFileFilter *mp3_filter = gtk_file_filter_new();
 	gtk_file_filter_add_pattern(mp3_filter, "*.mp3");
 	gtk_file_filter_set_name(mp3_filter, "MP3 Files (*.mp3)");
 	gtk_file_chooser_add_filter(chooser, mp3_filter);
+#endif
+#if HAVE_VORBISFILE == 1
+	GtkFileFilter *ogg_filter = gtk_file_filter_new();
+	gtk_file_filter_add_pattern(ogg_filter, "*.ogg");
+	gtk_file_filter_add_pattern(ogg_filter, "*.oga");
+	gtk_file_filter_set_name(mp3_filter, "Ogg Vorbis Files (*.ogg,*.oga)");
+	gtk_file_chooser_add_filter(chooser, ogg_filter);
+#endif
 	GtkFileFilter *all_filter = gtk_file_filter_new();
 	gtk_file_filter_add_pattern(all_filter, "*");
 	gtk_file_filter_set_name(all_filter, "All Files (*)");
@@ -1544,6 +1566,14 @@ void stack_audio_cue_register()
 	// Register cue types
 	StackCueClass* audio_cue_class = new StackCueClass{ "StackAudioCue", "StackCue", "Audio Cue", stack_audio_cue_create, stack_audio_cue_destroy, stack_audio_cue_play, NULL, stack_audio_cue_stop, stack_audio_cue_pulse, stack_audio_cue_set_tabs, stack_audio_cue_unset_tabs, stack_audio_cue_to_json, stack_audio_cue_free_json, stack_audio_cue_from_json, stack_audio_cue_get_error, stack_audio_cue_get_active_channels, stack_audio_cue_get_audio, stack_audio_cue_get_field, stack_audio_cue_get_icon, NULL, NULL };
 	stack_register_cue_class(audio_cue_class);
+
+	stack_log("stack_audio_cue_register(): Audio file support: Wave\n");
+#if HAVE_VORBISFILE == 1
+	stack_log("stack_audio_cue_register(): Audio file support: Ogg Vorbis\n");
+#endif
+#if HAVE_LIBMAD == 1
+	stack_log("stack_audio_cue_register(): Audio file support: MPEG Layer 3\n");
+#endif
 }
 
 // The entry point for the plugin that Stack calls

--- a/src/StackAudioFile.cpp
+++ b/src/StackAudioFile.cpp
@@ -4,6 +4,9 @@
 #if HAVE_LIBMAD == 1
 #include "StackAudioFileMP3.h"
 #endif
+#if HAVE_VORBISFILE == 1
+#include "StackAudioFileOgg.h"
+#endif
 #include "StackLog.h"
 
 static const float INT8_SCALAR = 7.8125e-3f;
@@ -53,7 +56,10 @@ StackAudioFile *stack_audio_file_create(const char *filename)
 	// Attempt to load as the various types
 	if (!((result = (StackAudioFile*)stack_audio_file_create_wave(stream))
 		  || stack_audio_file_reset_stream(stream)
-#if HAVE_LIBMAD == 1
+#if HAVE_VORBISFILE == 1
+		  || (result = (StackAudioFile*)stack_audio_file_create_ogg(stream))
+#endif
+#if HAVE_LIBMAD == 1 /* note that we do MP3 last as it doesn't always necessarily have a standard header */
 		  || (result = (StackAudioFile*)stack_audio_file_create_mp3(stream))
 #endif
 		))
@@ -85,6 +91,11 @@ void stack_audio_file_destroy(StackAudioFile *audio_file)
 		case STACK_AUDIO_FILE_FORMAT_WAVE:
 			stack_audio_file_destroy_wave((StackAudioFileWave*)audio_file);
 			break;
+#if HAVE_VORBISFILE == 1
+		case STACK_AUDIO_FILE_FORMAT_OGG:
+			stack_audio_file_destroy_ogg((StackAudioFileOgg*)audio_file);
+			break;
+#endif
 #if HAVE_LIBMAD == 1
 		case STACK_AUDIO_FILE_FORMAT_MP3:
 			stack_audio_file_destroy_mp3((StackAudioFileMP3*)audio_file);
@@ -101,6 +112,11 @@ void stack_audio_file_seek(StackAudioFile *audio_file, stack_time_t pos)
 		case STACK_AUDIO_FILE_FORMAT_WAVE:
 			stack_audio_file_seek_wave((StackAudioFileWave*)audio_file, pos);
 			break;
+#if HAVE_VORBISFILE == 1
+		case STACK_AUDIO_FILE_FORMAT_OGG:
+			stack_audio_file_seek_ogg((StackAudioFileOgg*)audio_file, pos);
+			break;
+#endif
 #if HAVE_LIBMAD == 1
 		case STACK_AUDIO_FILE_FORMAT_MP3:
 			stack_audio_file_seek_mp3((StackAudioFileMP3*)audio_file, pos);
@@ -119,6 +135,10 @@ size_t stack_audio_file_read(StackAudioFile *audio_file, float *buffer, size_t f
 	{
 		case STACK_AUDIO_FILE_FORMAT_WAVE:
 			return stack_audio_file_read_wave((StackAudioFileWave*)audio_file, buffer, frames);
+#if HAVE_VORBISFILE == 1
+		case STACK_AUDIO_FILE_FORMAT_OGG:
+			return stack_audio_file_read_ogg((StackAudioFileOgg*)audio_file, buffer, frames);
+#endif
 #if HAVE_LIBMAD == 1
 		case STACK_AUDIO_FILE_FORMAT_MP3:
 			return stack_audio_file_read_mp3((StackAudioFileMP3*)audio_file, buffer, frames);

--- a/src/StackAudioFile.h
+++ b/src/StackAudioFile.h
@@ -11,7 +11,7 @@ enum StackAudioFileFormat
     STACK_AUDIO_FILE_FORMAT_NONE = 0,
     STACK_AUDIO_FILE_FORMAT_WAVE = 1,
     STACK_AUDIO_FILE_FORMAT_MP3 = 2,
-	STACK_AUDIO_FILE_FORMAT_OGG = 3, // Reserved for future implementation
+	STACK_AUDIO_FILE_FORMAT_OGG = 3,
 	STACK_AUDIO_FILE_FORMAT_AAC = 4, // Reserved for future implementation
 };
 

--- a/src/StackAudioFileOgg.cpp
+++ b/src/StackAudioFileOgg.cpp
@@ -1,0 +1,168 @@
+#if HAVE_VORBISFILE == 1
+// Includes:
+#include <vorbis/codec.h>
+#include <vorbis/vorbisfile.h>
+#include "StackAudioFileOgg.h"
+#include "StackLog.h"
+
+#define OGG_DECODE_CHUNK_SIZE_SAMPLES 2048
+
+// Wrapper for vorbisfile so it can use GFile for read
+size_t ogg_gfile_wrapper_read(void *ptr, size_t size, size_t nmemb, void *datasource)
+{
+	size_t result = g_input_stream_read(G_INPUT_STREAM(datasource), ptr, size * nmemb, NULL, NULL);
+	return result / size;
+}
+
+// Wrapper for vorbisfile so it can use GFile for seek
+int ogg_gfile_wrapper_seek(void *datasource, ogg_int64_t offset, int whence)
+{
+	GSeekType seek_type;
+	switch (whence)
+	{
+		case SEEK_SET:
+			seek_type = G_SEEK_SET;
+			break;
+		case SEEK_CUR:
+			seek_type = G_SEEK_CUR;
+			break;
+		case SEEK_END:
+			seek_type = G_SEEK_END;
+			break;
+		default:
+			return -1;
+			break;
+	}
+
+	if (g_seekable_seek(G_SEEKABLE(datasource), offset, seek_type, NULL, NULL))
+	{
+		return 0;
+	}
+	else
+	{
+		return -1;
+	}
+}
+
+// Wrapper for vorbisfile so it can use GFile for close
+int ogg_gfile_wrapper_close(void *datasource)
+{
+	// We do nothing here, as StackAudioFile handles the closing of the stream
+	return 0;
+}
+
+// Wrapper for vorbisfile so it can use GFile for tell
+long ogg_gfile_wrapper_tell(void *datasource)
+{
+	return (long)g_seekable_tell(G_SEEKABLE(datasource));
+}
+
+StackAudioFileOgg *stack_audio_file_create_ogg(GFileInputStream *stream)
+{
+	// Define our functions for libvorbisfile to use for GFile operations as it
+	// only deals with stdio FILE* normally
+	static ov_callbacks callbacks = {
+		.read_func = ogg_gfile_wrapper_read,
+		.seek_func = ogg_gfile_wrapper_seek,
+		.close_func = ogg_gfile_wrapper_close,
+		.tell_func = ogg_gfile_wrapper_tell
+	};
+
+	// Rewind back to the start of the file, in case another format left us somewhere else
+	g_seekable_seek(G_SEEKABLE(stream), 0, G_SEEK_SET, NULL, NULL);
+
+	// Create a new object and attempt to open the file
+	StackAudioFileOgg *result = new StackAudioFileOgg;
+	int open_result = ov_open_callbacks((void*)stream, &result->file, NULL, 0, callbacks);
+	if (open_result != 0)
+	{
+		stack_log("stack_audio_file_create_ogg(): Not opening as Vorbis: %d\n", open_result);
+		delete result;
+		return NULL;
+	}
+
+	// Fill in the details about the file
+	vorbis_info *ogg_info = ov_info(&result->file, 0);
+	result->super.format = STACK_AUDIO_FILE_FORMAT_OGG;
+	result->super.channels = ogg_info->channels;
+	result->super.sample_rate = ogg_info->rate;
+	result->super.frames = ov_pcm_total(&result->file, 0);
+	result->super.length = (stack_time_t)(double(result->super.frames) / double(result->super.sample_rate) * NANOSECS_PER_SEC_F);
+	result->eof = false;
+
+	// Create a buffer of decoded frames
+	result->decoded_buffer = stack_ring_buffer_create(4096 * result->super.channels);
+
+	return result;
+}
+
+void stack_audio_file_destroy_ogg(StackAudioFileOgg *audio_file)
+{
+	// Tidy up libvorbisfile
+	ov_clear(&audio_file->file);
+
+	// Tidy up out ring buffer
+	stack_ring_buffer_destroy(audio_file->decoded_buffer);
+
+	// Tidy up ourselves
+	delete audio_file;
+}
+
+void stack_audio_file_seek_ogg(StackAudioFileOgg *audio_file, stack_time_t pos)
+{
+	if (ov_time_seek(&audio_file->file, (double)pos / NANOSECS_PER_SEC_F) < 0)
+	{
+		stack_log("stack_audio_file_seek_ogg(): Failed to seek\n");
+	}
+
+	audio_file->eof = false;
+	stack_ring_buffer_reset(audio_file->decoded_buffer);
+}
+
+void stack_audio_file_ogg_decode_more(StackAudioFileOgg *audio_file)
+{
+	// These two must be the same size
+	int16_t read_buffer[OGG_DECODE_CHUNK_SIZE_SAMPLES];
+	float conv_buffer[OGG_DECODE_CHUNK_SIZE_SAMPLES];
+
+	// Read 16-bit samples into our read buffer
+	long bytes_read = ov_read(&audio_file->file, (char*)read_buffer, OGG_DECODE_CHUNK_SIZE_SAMPLES * sizeof(int16_t), 0, sizeof(int16_t), 1, &audio_file->bitstream);
+	if (bytes_read <= 0)
+	{
+		// Assume any error or EOF as an end-of-file
+		audio_file->eof = true;
+	}
+	else
+	{
+		// Convert to float and add to our ring buffer
+		size_t samples_read = bytes_read / sizeof(int16_t);
+		stack_audio_file_convert(STACK_SAMPLE_FORMAT_INT16, read_buffer, samples_read, conv_buffer);
+		stack_ring_buffer_write(audio_file->decoded_buffer, conv_buffer, samples_read, 1);
+	}
+}
+
+size_t stack_audio_file_read_ogg(StackAudioFileOgg *audio_file, float *buffer, size_t frames)
+{
+	const size_t channels = audio_file->super.channels;
+
+	size_t frames_out = 0;
+	while (frames_out < frames && (audio_file->decoded_buffer->used > 0 || !audio_file->eof))
+	{
+		// Take an appropriate amount of data from the ring buffer
+		if (audio_file->decoded_buffer->used > 0)
+		{
+			frames_out += stack_ring_buffer_read(audio_file->decoded_buffer, &buffer[frames_out * channels], (frames - frames_out) * channels, 1) / channels;
+		}
+
+		// Try to keep 1024 samples in our ring buffer
+		if (audio_file->decoded_buffer->used < 1024 * channels && !audio_file->eof)
+		{
+			// Decode more Ogg data
+			stack_audio_file_ogg_decode_more(audio_file);
+		}
+	}
+
+	return frames_out;
+}
+
+#endif

--- a/src/StackAudioFileOgg.h
+++ b/src/StackAudioFileOgg.h
@@ -1,0 +1,27 @@
+#if HAVE_VORBISFILE == 1
+#ifndef _STACKAUDIOFILEOGG_H_INCLUDED
+#define  _STACKAUDIOFILEOGG_H_INCLUDED
+
+// Includes:
+#include "StackAudioFile.h"
+#include <vorbis/vorbisfile.h>
+#include "StackRingBuffer.h"
+
+struct StackAudioFileOgg
+{
+	StackAudioFile super;
+	OggVorbis_File file;
+	bool eof;
+	int bitstream;
+
+	// We read in blocks, so we need to buffer
+	StackRingBuffer *decoded_buffer;
+};
+
+StackAudioFileOgg *stack_audio_file_create_ogg(GFileInputStream *file);
+void stack_audio_file_destroy_ogg(StackAudioFileOgg *audio_file);
+void stack_audio_file_seek_ogg(StackAudioFileOgg* audio_file, stack_time_t pos);
+size_t stack_audio_file_read_ogg(StackAudioFileOgg *audio_file, float *buffer, size_t frames);
+
+#endif
+#endif

--- a/src/StackCueList.cpp
+++ b/src/StackCueList.cpp
@@ -1376,6 +1376,13 @@ void stack_cue_list_populate_buffers(StackCueList *cue_list, size_t samples)
 			mc_rms_data->peak_time = stack_get_clock_time();
 		}
 
+		// Some audio devices auto suspend - adding a tiny impulse of noise can
+		// prevent it on some of these devices
+		if (channel_rms == 0.0)
+		{
+			new_data[channel * request_samples] = 0.00005;
+		}
+
 		stack_ring_buffer_write(cue_list->buffers[channel], &new_data[channel * request_samples], request_samples, 1);
 	}
 


### PR DESCRIPTION
This commit also validates in the Docker test builds what optional components are not found, makes StackAudioCue log what file formats it supports, updates the UI for audio file selection to only show formats that are supported.

This branch additionally fixes an issue with some hardware where audio devices are automatically suspended if the output is all zero by adding a tiny impulse during the first sample of each channel in each block when necessary,